### PR TITLE
add support for derangement streams

### DIFF
--- a/doc/user_guide.adoc
+++ b/doc/user_guide.adoc
@@ -263,3 +263,43 @@ banana, Mars, coffee
 
 
 TIP: See link:{blob-root}/streamplify-examples/src/main/java/org/beryx/streamplify/example/RandomPoetry.java[RandomPoetry.java] for another example involving _CartesianProduct_.
+
+
+=== Derangements
+
+To generate streams of https://en.wikipedia.org/wiki/Derangement[derangements] of _n_ elements, _Streamplify_ offers the
+link:javadoc/org/beryx/streamplify/derangement/Derangements.html[Derangements] class,
+which is a _StreamableProxy_ that delegates to either
+link:javadoc/org/beryx/streamplify/derangement/LongDerangements.html[LongDerangements]
+or link:javadoc/org/beryx/streamplify/derangement/BigIntegerDerangements.html[BigIntegerDerangements],
+depending on the value of _n_.
+
+The code below uses the _Derangements_ class to solve the following problem: +
+_List all possible permutations of the word ABCD such that none of the letters remain in its original position._
+
+[source, java]
+.Print all derangements of the word ABCD
+----
+final String WORD = "ABCD";
+System.out.println(new Derangements(4)
+        .stream()
+        .map(combination -> Arrays.stream(combination)
+                .mapToObj(i -> Character.toString(WORD.charAt(i)))
+                .collect(Collectors.joining("")))
+        .collect(Collectors.joining("\n")));
+----
+
+.Output
+----
+BCDA
+BDAC
+BADC
+CADB
+CDBA
+CDAB
+DABC
+DCAB
+DCBA
+----
+
+TIP: See link:{blob-root}/streamplify-examples/src/main/java/org/beryx/streamplify/example/Hats.java[Hats.java] for a different version of the above example.

--- a/streamplify-examples/src/main/java/org/beryx/streamplify/example/Hats.java
+++ b/streamplify-examples/src/main/java/org/beryx/streamplify/example/Hats.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.example;
+
+import org.beryx.streamplify.derangement.Derangements;
+import org.beryx.streamplify.derangement.LongDerangements;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Generates <a href="https://en.wikipedia.org/wiki/Derangement">derangements</a>.
+ * <br>This implementation makes use of the {@link Derangements} class.
+ */
+public class Hats {
+    /**
+     * Solves the following problem:<pre>
+     * Alice, Bob, Chloe, David, and Emma have one hat each with their name on it.
+     * List all possible ways of assigning one hat to each person so that no one
+     * gets the hat that has their own name.</pre>
+     */
+    public static void main(String[] args) {
+        String[] names = {"Alice", "Bob", "Chloe", "David", "Emma"};
+        System.out.println("Original sequence:");
+        System.out.println(Arrays.toString(names));
+        System.out.println("All possible derangements:");
+        System.out.println(new Derangements(5)
+                .stream()
+                .map(arr -> Arrays.stream(arr).mapToObj(i -> names[i])
+                .collect(Collectors.toList()).toString())
+                .collect(Collectors.joining("\n")));
+    }
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/derangement/BigIntegerDerangements.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/derangement/BigIntegerDerangements.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.derangement;
+
+import org.beryx.streamplify.BigIntegerIndexedSpliterator;
+
+import java.math.BigInteger;
+
+/**
+ * Provides streams of derangements.
+ * <br>For derangements with a length <= 21, you may consider using the more efficient {@link LongDerangements}.
+ */
+public class BigIntegerDerangements extends BigIntegerIndexedSpliterator<int[], BigIntegerDerangements> {
+    public static final int MAX_LENGTH = 20_000;
+
+    /**
+     * Constructs derangements of {@code length} elements
+     */
+    public BigIntegerDerangements(int length) {
+        super(BigInteger.ZERO, subfactorial(length));
+        this.withValueSupplier(new DerangementSupplier.BigInt(length));
+        this.withAdditionalCharacteristics(DISTINCT);
+    }
+
+    /**
+     * @throws IllegalArgumentException if {@code n} is negative or too big (> {@value #MAX_LENGTH})
+     */
+    public static BigInteger subfactorial(int n) {
+        if (n < 0) throw new IllegalArgumentException("Invalid derangement length: " + n);
+        if (n > MAX_LENGTH) throw new IllegalArgumentException("Value too big: " + n);
+        if (n == 0) return BigInteger.ONE;
+        BigInteger prev = BigInteger.ONE;
+        BigInteger curr = BigInteger.ZERO;
+        for (int i = 2; i <= n; ++i) {
+            BigInteger next = BigInteger.valueOf(i - 1).multiply(curr.add(prev));
+            prev = curr;
+            curr = next;
+        }
+        return curr;
+    }
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/derangement/DerangementSupplier.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/derangement/DerangementSupplier.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.derangement;
+
+import org.beryx.streamplify.IntArraySupplier;
+import org.beryx.streamplify.Splittable;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * A value supplier for derangements.
+ * <br>Computes the next derangement based on an index.
+ */
+public abstract class DerangementSupplier implements IntArraySupplier {
+    protected final int length;
+    protected final int[] currentSequence;
+
+    DerangementSupplier(int length) {
+        this.length = length;
+        this.currentSequence = new int[length];
+    }
+
+    public void init() {
+        int[] tmp = new DerangementSupplier.Long(length).apply(0);
+        System.arraycopy(tmp, 0, currentSequence, 0, length);
+    }
+
+    @Override
+    public int[] getCurrentSequence() {
+        return currentSequence;
+    }
+
+    public void computeNext() {
+        throw new UnsupportedOperationException("computeNext is not supported");
+    }
+
+    public static class Long extends DerangementSupplier implements Splittable.LongIndexed<int[]> {
+        private final long[] subfactorial;
+
+        private long currentIndex = -2;
+
+        public Long(int length) {
+            this(length, computeSubfactorial(length));
+        }
+
+        private Long(int length, long[] subfactorial) {
+            super(length);
+            this.subfactorial = subfactorial;
+        }
+
+        @Override
+        public Long split() {
+            return new Long(length, subfactorial);
+        }
+
+        @Override
+        public int[] apply(long index) {
+            currentIndex = index;
+            return getNextSequence(false);
+        }
+
+        @Override
+        public int[] unrank() {
+            int[] seq = new int[length];
+            Arrays.fill(seq, -1);
+            int[] avoid = new int[length];
+            for (int i = 0; i < length; ++i) {
+                avoid[i] = i;
+            }
+            int[] reverse = new int[length];
+            System.arraycopy(avoid, 0, reverse, 0, length);
+            boolean[] taken = new boolean[length];
+            long index = currentIndex;
+            int remaining = length;
+            for (int i = 0; i < length; ++i) {
+                if (seq[i] == -1) {
+                    int peer = 0;
+                    if (remaining > 1) {
+                        long comb = subfactorial[remaining - 1] + subfactorial[remaining - 2];
+                        peer = (int) (index/comb);
+                        index -= peer*comb;
+                    }
+                    int j = 0;
+                    while (taken[j] || j == avoid[i] || peer > 0) {
+                        if (!taken[j] && j != avoid[i]) --peer;
+                        ++j;
+                    }
+                    seq[i] = j;
+                    taken[j] = true;
+                    if (index < subfactorial[remaining - 1]) {
+                        avoid[reverse[j]] = avoid[i];
+                        reverse[avoid[i]] = reverse[j];
+                        --remaining;
+                    } else {
+                        seq[reverse[j]] = avoid[i];
+                        taken[avoid[i]] = true;
+                        index -= subfactorial[remaining - 1];
+                        remaining -= 2;
+                    }
+                }
+            }
+            return seq;
+        }
+
+        private static long[] computeSubfactorial(int len) {
+            if (len < 0) {
+                return null;
+            }
+            long[] subf = new long[len + 1];
+            subf[0] = 1;
+            if (len < 1) {
+                return subf;
+            }
+            subf[1] = 0;
+            for (int i = 2; i <= len; ++i) {
+                subf[i] = (i - 1)*(subf[i - 1] + subf[i - 2]);
+            }
+            return subf;
+        }
+    }
+
+    public static class BigInt extends DerangementSupplier implements Splittable.BigIntegerIndexed<int[]> {
+        private final BigInteger[] subfactorial;
+        private BigInteger currentIndex = BigInteger.valueOf(-2);
+
+        public BigInt(int length) {
+            this(length, computeSubfactorial(length));
+        }
+
+        private BigInt(int length, BigInteger[] subfactorial) {
+            super(length);
+            this.subfactorial = subfactorial;
+        }
+
+        @Override
+        public BigInt split() {
+            return new BigInt(length, subfactorial);
+        }
+
+        @Override
+        public int[] apply(BigInteger index) {
+            currentIndex = index;
+            return getNextSequence(false);
+        }
+
+        @Override
+        public int[] unrank() {
+            int[] seq = new int[length];
+            Arrays.fill(seq, -1);
+            int[] avoid = new int[length];
+            for (int i = 0; i < length; ++i) {
+                avoid[i] = i;
+            }
+            int[] reverse = new int[length];
+            System.arraycopy(avoid, 0, reverse, 0, length);
+            boolean[] taken = new boolean[length];
+            BigInteger index = currentIndex;
+            int remaining = length;
+            for (int i = 0; i < length; ++i) {
+                if (seq[i] == -1) {
+                    int peer = 0;
+                    if (remaining > 1) {
+                        BigInteger comb = subfactorial[remaining - 1].add(subfactorial[remaining - 2]);
+                        peer = index.divide(comb).intValue();
+                        index = index.subtract(BigInteger.valueOf(peer).multiply(comb));
+                    }
+                    int j = 0;
+                    while (taken[j] || j == avoid[i] || peer > 0) {
+                        if (!taken[j] && j != avoid[i]) --peer;
+                        ++j;
+                    }
+                    seq[i] = j;
+                    taken[j] = true;
+                    if (index.compareTo(subfactorial[remaining - 1]) == -1) {
+                        avoid[reverse[j]] = avoid[i];
+                        reverse[avoid[i]] = reverse[j];
+                        --remaining;
+                    } else {
+                        seq[reverse[j]] = avoid[i];
+                        taken[avoid[i]] = true;
+                        index = index.subtract(subfactorial[remaining - 1]);
+                        remaining -= 2;
+                    }
+                }
+            }
+            return seq;
+        }
+
+        private static BigInteger[] computeSubfactorial(int len) {
+            if (len < 0) {
+                return null;
+            }
+            BigInteger[] subf = new BigInteger[len + 1];
+            subf[0] = BigInteger.ONE;
+            if (len < 1) {
+                return subf;
+            }
+            subf[1] = BigInteger.ZERO;
+            for (int i = 2; i <= len; ++i) {
+                subf[i] = BigInteger.valueOf(i - 1).multiply(subf[i - 1].add(subf[i - 2]));
+            }
+            return subf;
+        }
+    }
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/derangement/Derangements.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/derangement/Derangements.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.derangement;
+
+import org.beryx.streamplify.Streamable;
+import org.beryx.streamplify.StreamableProxy;
+
+/**
+ * A {@link Streamable} providing streams of derangements.
+ * <br>This class is a proxy that delegates to either {@link LongDerangements} or {@link BigIntegerDerangements}, depending on the derangement length.
+ */
+public class Derangements extends StreamableProxy<int[], Derangements> {
+
+    private final Streamable<int[], ?> delegate;
+
+    /**
+     * @param length the derangement length
+     */
+    public Derangements(int length) {
+        if (length <= LongDerangements.MAX_LENGTH) {
+            delegate = new LongDerangements(length);
+        } else {
+            delegate = new BigIntegerDerangements(length);
+        }
+    }
+
+    @Override
+    public Streamable<int[], ?> getDelegate() {
+        return delegate;
+    }
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/derangement/LongDerangements.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/derangement/LongDerangements.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.derangement;
+
+import org.beryx.streamplify.LongIndexedSpliterator;
+
+/**
+ * Provides streams of derangements.
+ * <br>Can be used for derangements with a maximum length of {@value #MAX_LENGTH}.
+ * For bigger values, a {@link BigIntegerDerangements} is needed.
+ */
+public class LongDerangements extends LongIndexedSpliterator<int[], LongDerangements> {
+    public static final int MAX_LENGTH = 21;
+
+    /**
+     * Constructs derangements of {@code length} elements
+     */
+    public LongDerangements(int length) {
+        super(0, subfactorial(length));
+        this.withValueSupplier(new DerangementSupplier.Long(length));
+        this.withAdditionalCharacteristics(DISTINCT);
+    }
+
+    /**
+     * @throws IllegalArgumentException if {@code n} is negative or the result does not fit in a long (that is, {@code n} > {@value #MAX_LENGTH})
+     */
+    public static long subfactorial(int n) {
+        if (n < 0) throw new IllegalArgumentException("Invalid derangement length: " + n);
+        if (n > MAX_LENGTH) throw new IllegalArgumentException("Derangement length too big: " + n);
+        if (n == 0) return 1;
+        long prev = 1;
+        long curr = 0;
+        for (int i = 2; i <= n; ++i) {
+            long next = (i - 1)*(curr + prev);
+            prev = curr;
+            curr = next;
+        }
+        return curr;
+    }
+}

--- a/streamplify/src/test/groovy/org/beryx/streamplify/DerangementsSpec.groovy
+++ b/streamplify/src/test/groovy/org/beryx/streamplify/DerangementsSpec.groovy
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify
+
+import org.beryx.streamplify.derangement.BigIntegerDerangements
+import org.beryx.streamplify.derangement.LongDerangements
+import org.beryx.streamplify.derangement.Derangements
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.stream.Collectors
+
+@Unroll
+class DerangementsSpec extends Specification {
+
+    def "LongDerangements should throw IllegalArgumentException for length #length"() {
+        when:
+        def derangements = new LongDerangements(length)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        length                      | _
+        -1                          | _
+        -2                          | _
+        22                          | _
+        Integer.MAX_VALUE           | _
+        -Integer.MAX_VALUE          | _
+    }
+
+    def "BigIntegerDerangements should throw IllegalArgumentException for length #length"() {
+        when:
+        def derangements = new BigIntegerDerangements(length)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        length                                | _
+        -1                                    | _
+        -2                                    | _
+        BigIntegerDerangements.MAX_LENGTH + 1 | _
+        Integer.MAX_VALUE                     | _
+        -Integer.MAX_VALUE                    | _
+    }
+
+    def "should use a #delegateClass.simpleName for length #length"() {
+        given:
+        def derangements = new Derangements(length)
+
+        expect:
+        derangements.delegate.getClass().name == delegateClass.name
+
+        where:
+        length                            | delegateClass
+        0                                 | LongDerangements
+        1                                 | LongDerangements
+        2                                 | LongDerangements
+        LongDerangements.MAX_LENGTH       | LongDerangements
+        (LongDerangements.MAX_LENGTH + 1) | BigIntegerDerangements
+        BigIntegerDerangements.MAX_LENGTH | BigIntegerDerangements
+    }
+
+    def "LongDerangements should correctly produce a derangement stream for length #length"() {
+        given:
+        def stream = new LongDerangements(length).stream()
+
+        when:
+        def seq = stream.map { int[] arr -> (arr as List).toString() }.collect(Collectors.toList())
+
+        then:
+        seq == derangements
+
+        where:
+        length | derangements
+        0      | ['[]']
+        1      | []
+        2      | ['[1, 0]']
+        3      | ['[1, 2, 0]', '[2, 0, 1]']
+        4      | ['[1, 2, 3, 0]', '[1, 3, 0, 2]', '[1, 0, 3, 2]', '[2, 0, 3, 1]', '[2, 3, 1, 0]', '[2, 3, 0, 1]', '[3, 0, 1, 2]', '[3, 2, 0, 1]', '[3, 2, 1, 0]']
+        5      | ['[1, 2, 3, 4, 0]', '[1, 2, 4, 0, 3]', '[1, 2, 0, 4, 3]', '[1, 3, 0, 4, 2]', '[1, 3, 4, 2, 0]', '[1, 3, 4, 0, 2]', '[1, 4, 0, 2, 3]', '[1, 4, 3, 0, 2]', '[1, 4, 3, 2, 0]', '[1, 0, 3, 4, 2]', '[1, 0, 4, 2, 3]', '[2, 0, 3, 4, 1]', '[2, 0, 4, 1, 3]', '[2, 0, 1, 4, 3]', '[2, 3, 1, 4, 0]', '[2, 3, 4, 0, 1]', '[2, 3, 4, 1, 0]', '[2, 4, 1, 0, 3]', '[2, 4, 3, 1, 0]', '[2, 4, 3, 0, 1]', '[2, 3, 0, 4, 1]', '[2, 4, 0, 1, 3]', '[3, 0, 1, 4, 2]', '[3, 0, 4, 2, 1]', '[3, 0, 4, 1, 2]', '[3, 2, 0, 4, 1]', '[3, 2, 4, 1, 0]', '[3, 2, 1, 4, 0]', '[3, 4, 0, 1, 2]', '[3, 4, 1, 2, 0]', '[3, 4, 0, 2, 1]', '[3, 2, 4, 0, 1]', '[3, 4, 1, 0, 2]', '[4, 0, 1, 2, 3]', '[4, 0, 3, 1, 2]', '[4, 0, 3, 2, 1]', '[4, 2, 0, 1, 3]', '[4, 2, 3, 0, 1]', '[4, 2, 1, 0, 3]', '[4, 3, 0, 2, 1]', '[4, 3, 1, 0, 2]', '[4, 3, 0, 1, 2]', '[4, 2, 3, 1, 0]', '[4, 3, 1, 2, 0]']
+    }
+
+    def "BigIntegerDerangements should correctly produce a derangement stream for length #length"() {
+        given:
+        def stream = new BigIntegerDerangements(length).stream()
+
+        when:
+        def seq = stream.map { int[] arr -> (arr as List).toString() }.collect(Collectors.toList())
+
+        then:
+        seq == derangements
+
+        where:
+        length | derangements
+        0      | ['[]']
+        1      | []
+        2      | ['[1, 0]']
+        3      | ['[1, 2, 0]', '[2, 0, 1]']
+        4      | ['[1, 2, 3, 0]', '[1, 3, 0, 2]', '[1, 0, 3, 2]', '[2, 0, 3, 1]', '[2, 3, 1, 0]', '[2, 3, 0, 1]', '[3, 0, 1, 2]', '[3, 2, 0, 1]', '[3, 2, 1, 0]']
+        5      | ['[1, 2, 3, 4, 0]', '[1, 2, 4, 0, 3]', '[1, 2, 0, 4, 3]', '[1, 3, 0, 4, 2]', '[1, 3, 4, 2, 0]', '[1, 3, 4, 0, 2]', '[1, 4, 0, 2, 3]', '[1, 4, 3, 0, 2]', '[1, 4, 3, 2, 0]', '[1, 0, 3, 4, 2]', '[1, 0, 4, 2, 3]', '[2, 0, 3, 4, 1]', '[2, 0, 4, 1, 3]', '[2, 0, 1, 4, 3]', '[2, 3, 1, 4, 0]', '[2, 3, 4, 0, 1]', '[2, 3, 4, 1, 0]', '[2, 4, 1, 0, 3]', '[2, 4, 3, 1, 0]', '[2, 4, 3, 0, 1]', '[2, 3, 0, 4, 1]', '[2, 4, 0, 1, 3]', '[3, 0, 1, 4, 2]', '[3, 0, 4, 2, 1]', '[3, 0, 4, 1, 2]', '[3, 2, 0, 4, 1]', '[3, 2, 4, 1, 0]', '[3, 2, 1, 4, 0]', '[3, 4, 0, 1, 2]', '[3, 4, 1, 2, 0]', '[3, 4, 0, 2, 1]', '[3, 2, 4, 0, 1]', '[3, 4, 1, 0, 2]', '[4, 0, 1, 2, 3]', '[4, 0, 3, 1, 2]', '[4, 0, 3, 2, 1]', '[4, 2, 0, 1, 3]', '[4, 2, 3, 0, 1]', '[4, 2, 1, 0, 3]', '[4, 3, 0, 2, 1]', '[4, 3, 1, 0, 2]', '[4, 3, 0, 1, 2]', '[4, 2, 3, 1, 0]', '[4, 3, 1, 2, 0]']
+    }
+
+    def "should skip correctly #skip derangements with length #length"() {
+        given:
+        def stream = new Derangements(length).skip(skip).stream()
+
+        when:
+        def seq = stream.map { int[] arr -> (arr as List).toString() }.findFirst().orElse('')
+
+        then:
+        seq == derangement
+
+        where:
+        length | skip                                           | derangement
+        0      | 0                                              | '[]'
+        0      | 1                                              | ''
+        1      | 0                                              | ''
+        2      | 0                                              | '[1, 0]'
+        2      | 1                                              | ''
+        3      | 0                                              | '[1, 2, 0]'
+        3      | 1                                              | '[2, 0, 1]'
+        3      | 2                                              | ''
+        4      | 0                                              | '[1, 2, 3, 0]'
+        4      | 8                                              | '[3, 2, 1, 0]'
+        4      | 9                                              | ''
+        5      | 42                                             | '[4, 2, 3, 1, 0]'
+        25     | (new BigInteger('1234567890123456789012345'))  | '[6, 5, 17, 0, 23, 2, 10, 3, 11, 16, 4, 7, 13, 14, 15, 20, 21, 8, 22, 9, 1, 19, 12, 24, 18]'
+        25     | (new BigInteger('12345678901234567890123456')) | ''
+    }
+}


### PR DESCRIPTION
Implements issue #2:
- Add support for derangement streams
- Add docs using Asciidoctor
- Add test: DerangementsSpec.groovy
- Add example: Hats.java
- computeNext() is left unimplemented as I couldn't find an implementation that's not overcomplicated and clearly more efficient than unrank()
