### PR TITLE
Add support for partial permutation streams

### DIFF
--- a/doc/user_guide.adoc
+++ b/doc/user_guide.adoc
@@ -347,3 +347,67 @@ Bob Chloe David
 Alice Bob Chloe David 
 ----
 
+=== Partial Permutations
+
+To generate streams of https://en.wikipedia.org/wiki/Partial_permutation[partial permutations] of _n_ elements, _Streamplify_ offers the
+link:javadoc/org/beryx/streamplify/partperm/PartialPermutations.html[PartialPermutations] class,
+which is a _StreamableProxy_ that delegates to either
+link:javadoc/org/beryx/streamplify/partperm/LongPartialPermutations.html[LongPartialPermutations]
+or link:javadoc/org/beryx/streamplify/partperm/BigIntegerPartialPermutations.html[BigIntegerPartialPermutations],
+depending on the value of _n_.
+
+The code below uses the _PartialPermutations_ class to solve the following problem: +
+_List all possible permutations of the letters ABC such that any letter(s) can be replaced by "__"
+
+[source, java]
+.Print all partial permutations of the letters ABC
+----
+final String WORD = "ABC";
+final String BLANK = "_";
+System.out.println(new PartialPermutations(WORD.length())
+        .stream()
+        .map(combination -> Arrays.stream(combination)
+                .mapToObj(i -> i == PartialPermutationSupplier.HOLE ? BLANK : Character.toString(WORD.charAt(i)))
+                .collect(Collectors.joining("")))
+        .collect(Collectors.joining("\n")));
+----
+
+.Output
+----
+___
+__A
+_A_
+A__
+__B
+_B_
+B__
+__C
+_C_
+C__
+_AB
+_BA
+A_B
+AB_
+B_A
+BA_
+_AC
+_CA
+A_C
+AC_
+C_A
+CA_
+_BC
+_CB
+B_C
+BC_
+C_B
+CB_
+ABC
+ACB
+BAC
+BCA
+CAB
+CBA
+----
+
+TIP: See link:{blob-root}/streamplify-examples/src/main/java/org/beryx/streamplify/example/Vacation.java[Vacation.java] for a different version of the above example.

--- a/streamplify-examples/src/main/java/org/beryx/streamplify/example/Vacation.java
+++ b/streamplify-examples/src/main/java/org/beryx/streamplify/example/Vacation.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.example;
+
+import org.beryx.streamplify.partperm.PartialPermutationSupplier;
+import org.beryx.streamplify.partperm.PartialPermutations;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Illustrates the use of {@link PartialPermutations} by solving the following problem:<pre>
+ * You have an activity you want to do for each day of your vacation
+ * but on any day you may instead choose to explore.
+ * Print all possible itineraries for your vacation.</pre>
+ */
+public class Vacation {
+
+    public static void main(String[] args) {
+        String[] thingsToDoOnVacation = {"Hiking", "Museum"};
+        String thingToDoInstead = "Explore";
+
+        System.out.print("Things I want to do on vacation: ");
+        printFormattedString(Arrays.toString(thingsToDoOnVacation), ", ");
+        System.out.println("But instead I might " + thingToDoInstead + "\n");
+        System.out.println("All possible itineraries:\n");
+
+        System.out.println(IntStream.range(1, thingsToDoOnVacation.length + 1)
+                .mapToObj(i -> "-Day " + i + "-")
+                .collect(Collectors.joining("\t")));
+
+        printFormattedString(new PartialPermutations(thingsToDoOnVacation.length)
+                .stream()
+                .map(arr -> Arrays.stream(arr).mapToObj(i -> i == PartialPermutationSupplier.HOLE ? thingToDoInstead : thingsToDoOnVacation[i])
+                        .collect(Collectors.toList()).toString())
+                .collect(Collectors.joining("\n")), "\t");
+    }
+
+    private static void printFormattedString(String output, String delimiter) {
+        System.out.println(output.replaceAll(",? ", delimiter).replaceAll("]|\\[", ""));
+    }
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/partperm/BigIntegerPartialPermutations.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/partperm/BigIntegerPartialPermutations.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.partperm;
+
+import org.beryx.streamplify.BigIntegerIndexedSpliterator;
+
+import java.math.BigInteger;
+
+/**
+ * Provides streams of partial permutations.
+ * <br>For permutations with a length <= 18, you may consider using the more efficient {@link LongPartialPermutations}.
+ */
+public class BigIntegerPartialPermutations extends BigIntegerIndexedSpliterator<int[], BigIntegerPartialPermutations> {
+    public static final int MAX_LENGTH = 10_000;
+
+    /**
+     * Constructs partial permutations of {@code length} elements
+     */
+    public BigIntegerPartialPermutations(int length) {
+        super(BigInteger.ZERO, numberOfPermutations(length));
+        this.withValueSupplier(new PartialPermutationSupplier.BigInt(length));
+        this.withAdditionalCharacteristics(DISTINCT);
+    }
+
+    /**
+     * @throws IllegalArgumentException if {@code n} is negative or too big (> {@value #MAX_LENGTH})
+     */
+    public static BigInteger numberOfPermutations(int n) {
+        if (n < 0) throw new IllegalArgumentException("Invalid partial permutation length: " + n);
+        if (n > MAX_LENGTH) throw new IllegalArgumentException("Partial permutation length too big: " + n);
+
+        BigInteger[] factorials = computeFactorials(n);
+        BigInteger numberOfPermutations = BigInteger.ZERO;
+        for (int i = 0; i <= n; i++) {
+            numberOfPermutations = numberOfPermutations.add(computeNextNcK(n, factorials, i));
+        }
+        return numberOfPermutations;
+    }
+
+    public static BigInteger[] computeFactorials(int length) {
+        BigInteger[] factorials = new BigInteger[length + 1];
+        factorials[0] = BigInteger.ONE;
+        for (int i = 1; i <= length; i++) {
+            factorials[i] = factorials[i - 1].multiply(BigInteger.valueOf(i));
+        }
+        return factorials;
+    }
+
+    private static BigInteger computeNextNcK(int n, BigInteger[] factorials, int i) {
+        BigInteger nCk = factorials[n].divide(factorials[i].multiply(factorials[n - i]));
+        return factorials[i].multiply(nCk.pow(2));
+    }
+
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/partperm/LongPartialPermutations.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/partperm/LongPartialPermutations.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.partperm;
+
+import org.beryx.streamplify.LongIndexedSpliterator;
+
+/**
+ * Provides streams of partial permutations.
+ * <br>Can be used for partial permutations with a maximum length of {@value #MAX_LENGTH}.
+ * For bigger values, a {@link BigIntegerPartialPermutations} is needed.
+ */
+public class LongPartialPermutations extends LongIndexedSpliterator<int[], LongPartialPermutations> {
+    public static final int MAX_LENGTH = 18;
+
+    /**
+     * Constructs partial permutations of {@code length} elements
+     */
+    public LongPartialPermutations(int length) {
+        super(0, numberOfPermutations(length));
+        this.withValueSupplier(new PartialPermutationSupplier.Long(length));
+        this.withAdditionalCharacteristics(DISTINCT);
+    }
+
+    /**
+     * @throws IllegalArgumentException if {@code n} is negative or the result does not fit in a long (that is, {@code n} > {@value #MAX_LENGTH})
+     */
+    public static long numberOfPermutations(int n) {
+        if (n < 0) throw new IllegalArgumentException("Invalid partial permutation length: " + n);
+        if (n > MAX_LENGTH) throw new IllegalArgumentException("Partial permutation length too big: " + n);
+        if (n == 0) return 1;
+        if (n == 1) return 2;
+        return 2 * n * numberOfPermutations(n - 1) - (long) Math.pow(n - 1, 2) * numberOfPermutations(n - 2);
+    }
+
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/partperm/PartialPermutationSupplier.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/partperm/PartialPermutationSupplier.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.partperm;
+
+import org.beryx.streamplify.IntArraySupplier;
+import org.beryx.streamplify.Splittable;
+import org.beryx.streamplify.combination.CombinationSupplier;
+
+import java.math.BigInteger;
+import java.util.stream.IntStream;
+
+/**
+ * A value supplier for partial permutations.
+ * <br>It may compute the next partial permutation based on the current one, or by unranking an index.
+ */
+public abstract class PartialPermutationSupplier implements IntArraySupplier {
+    public static final int HOLE = -1;
+
+    protected final int length;
+    protected final int[] currentPartialPermutation;
+
+    PartialPermutationSupplier(int length) {
+        this.length = length;
+        this.currentPartialPermutation = new int[length];
+    }
+
+    @Override
+    public int[] getCurrentSequence() {
+        return currentPartialPermutation;
+    }
+
+    public void computeNext() {
+        if (!nextPermutation(currentPartialPermutation)) {
+            int[] currentCombination = extractCurrentCombination(currentPartialPermutation);
+
+            if (currentCombination != null && nextCombination(currentCombination, length)) {
+                int[] nextCombination = generateInitialSequence(currentCombination, length);
+                System.arraycopy(nextCombination, 0, currentPartialPermutation, 0, length);
+            } else {
+                if (currentCombination.length == length) return;
+
+                int[] newSubset = IntStream.range(0, currentCombination.length + 1).toArray();
+                int[] newStartingCombination = generateInitialSequence(newSubset, length);
+                System.arraycopy(newStartingCombination, 0, currentPartialPermutation, 0, length);
+            }
+        }
+    }
+
+    private int[] extractCurrentCombination(int[] permutation) {
+        int endOfCombination = endOfCombination(permutation);
+
+        int[] combination;
+        combination = new int[endOfCombination];
+        for (int i = endOfCombination - 1; i >= 0; i--) {
+            combination[endOfCombination - i - 1] = permutation[i];
+        }
+
+        return combination;
+    }
+
+    private int endOfCombination(int[] array) {
+        for (int i = 0; i < array.length; i++) {
+            if (array[i] == HOLE) return i;
+        }
+        return array.length;
+    }
+
+    private static int[] generateInitialSequence(int[] currentCombination, int totalLength) {
+        int[] initialSequence = new int[totalLength];
+        int numberOfHoleElements = totalLength - currentCombination.length;
+
+        for (int i = 0; i < totalLength; i++) {
+            initialSequence[i] = i < numberOfHoleElements ? HOLE : currentCombination[i - numberOfHoleElements];
+        }
+
+        return initialSequence;
+    }
+
+    static boolean nextPermutation(int[] array) {
+        int pos = array.length - 1;
+        while (pos > 0 && array[pos - 1] >= array[pos])
+            pos--;
+
+        if (pos <= 0) return false;
+
+        int swapIdx = array.length - 1;
+        int pivotPos = pos - 1;
+        while (array[swapIdx] <= array[pivotPos])
+            swapIdx--;
+
+        swap(array, pivotPos, swapIdx);
+
+        swapIdx = array.length - 1;
+        while (pos < swapIdx) {
+            swap(array, pos, swapIdx);
+            pos++;
+            swapIdx--;
+        }
+
+        return true;
+    }
+
+    private static void swap(int[] array, int pos, int swapIdx) {
+        int temp = array[pos];
+        array[pos] = array[swapIdx];
+        array[swapIdx] = temp;
+    }
+
+    /**
+     * Parameterized version of {@link CombinationSupplier.Long#computeNext()}
+     */
+    public static boolean nextCombination(int[] currentCombination, int n) {
+        int k = currentCombination.length;
+        int pos = k - 1;
+        while (pos >= 0 && currentCombination[pos] >= n - k + pos) pos--;
+        if (pos < 0) return false;
+        int val = currentCombination[pos];
+        for (int i = pos; i < k; i++) {
+            currentCombination[i] = ++val;
+        }
+        return true;
+    }
+
+    public static class Long extends PartialPermutationSupplier implements Splittable.LongIndexed<int[]> {
+        private final long[] divisors;
+        private long currentIndex = -2;
+
+        public Long(int length) {
+            this(length, computeDivisors(length));
+        }
+
+        private Long(int length, long[] divisors) {
+            super(length);
+            this.divisors = divisors;
+        }
+
+        @Override
+        public Long split() {
+            return new Long(length, divisors);
+        }
+
+        @Override
+        public int[] apply(long index) {
+            boolean useNext = (index == currentIndex + 1);
+            currentIndex = index;
+            return getNextSequence(useNext);
+        }
+
+        @Override
+        public int[] unrank() {
+            if (length == 0) return new int[0];
+
+            long prevPermutationCounter = 1;
+            BigInteger nCk = BigInteger.ONE;
+
+            int subsetSize = 1;
+            long permutationCounter = 0;
+            while (permutationCounter < currentIndex) {
+                prevPermutationCounter = permutationCounter;
+                nCk = BigInt.computeNextNchooseK(nCk, length, subsetSize - 1);
+                permutationCounter += divisors[subsetSize] * Math.pow(nCk.longValue(), 2);
+
+                subsetSize++;
+            }
+            subsetSize--;
+
+            long partialPermutationIndex = currentIndex - prevPermutationCounter;
+            return urankPartialPermutation(partialPermutationIndex, nCk, subsetSize);
+        }
+
+        private int[] urankPartialPermutation(long partialPermutationIndex, BigInteger nCk, int subsetSize) {
+            int numberOfHoleElements = length - subsetSize;
+
+            long lengthOfPermutations = divisors[length] / divisors[numberOfHoleElements];
+            long combinationIndex = Math.floorDiv(partialPermutationIndex, lengthOfPermutations);
+            long permutationIndex = Math.floorMod(partialPermutationIndex, lengthOfPermutations);
+
+            if (permutationIndex == 0) {
+                combinationIndex--;
+                permutationIndex = lengthOfPermutations;
+            }
+
+            int[] currentCombination = unrankCombination(length, subsetSize, nCk.intValue(), combinationIndex);
+            int[] permutationStart = PartialPermutationSupplier.generateInitialSequence(currentCombination, length);
+            return unrankPermutation(permutationStart, permutationIndex - 1, numberOfHoleElements, lengthOfPermutations);
+        }
+
+        /**
+         * Parameterized version of {@link CombinationSupplier.Long#unrank()}
+         * <p>
+         * This implementation uses the UNRANKCOMB-D algorithm introduced in:
+         * Kokosinski, Zbigniew, and Ikki-Machi Tsuruga. "Algorithms for unranking combinations and other related choice functions." (1995).
+         */
+        private static int[] unrankCombination(int n, int k, long count, long currentIndex) {
+            if (k == 0) return new int[0];
+            int[] combi = new int[k];
+            long rank = count - 1 - currentIndex;
+            long e = (n - k) * count / n;
+            int t = n - k + 1;
+            int m = k;
+            int p = n - 1;
+            do {
+                if (e <= rank) {
+                    combi[k - m] = n - t - m + 1;
+                    if (e > 0) {
+                        rank = rank - e;
+                        e = m * e / p;
+                    }
+                    m--;
+                    p--;
+                } else {
+                    e = (p - m) * e / p;
+                    t--;
+                    p--;
+                }
+            } while (m > 0);
+            return combi;
+        }
+
+        private int[] unrankPermutation(int[] permutation, long rank, int numberOfHoleElements, long possiblePermutations) {
+            for (int step = 0; step < permutation.length; step++) {
+                int elementFrequency = Math.max(numberOfHoleElements, 1);
+                long possibleSuffixes = possiblePermutations * elementFrequency / (length - step);
+
+                if (rank < possibleSuffixes) {
+                    if (permutation[step] == HOLE) {
+                        numberOfHoleElements--;
+                    }
+
+                    possiblePermutations = possibleSuffixes;
+                } else {
+                    if (numberOfHoleElements > 1) {
+                        rank -= possibleSuffixes;
+                        possibleSuffixes = possiblePermutations / (length - step);
+                    }
+                    int targetOffset = (int) (rank / possibleSuffixes);
+                    rank -= possibleSuffixes * targetOffset;
+
+                    if (numberOfHoleElements > 1) targetOffset += numberOfHoleElements;
+                    reorderPermutation(permutation, step, targetOffset);
+
+                    possiblePermutations = possibleSuffixes;
+                }
+
+            }
+            return permutation;
+        }
+
+        private static void reorderPermutation(int[] initialPermutation, int currentIndex, int swapOffset) {
+            int valToSwap = initialPermutation[currentIndex + swapOffset];
+            System.arraycopy(initialPermutation, currentIndex, initialPermutation, currentIndex + 1, swapOffset);
+            initialPermutation[currentIndex] = valToSwap;
+        }
+
+        private static long[] computeDivisors(int len) {
+            if (len < 1) return null;
+            long[] divs = new long[len + 1];
+            long fac = 1;
+            divs[0] = 1;
+            for (int i = 1; i <= len; i++) {
+                fac *= i;
+                divs[i] = fac;
+            }
+            return divs;
+        }
+    }
+
+    public static class BigInt extends PartialPermutationSupplier implements Splittable.BigIntegerIndexed<int[]> {
+        private final BigInteger[] divisors;
+        private BigInteger currentIndex = BigInteger.valueOf(-2);
+
+        public BigInt(int length) {
+            this(length, BigIntegerPartialPermutations.computeFactorials(length));
+        }
+
+        private BigInt(int length, BigInteger[] divisors) {
+            super(length);
+            this.divisors = divisors;
+        }
+
+        @Override
+        public BigInt split() {
+            return new BigInt(length, divisors);
+        }
+
+        @Override
+        public int[] apply(BigInteger index) {
+            boolean useNext = index.equals(currentIndex.add(BigInteger.ONE));
+            currentIndex = index;
+            return getNextSequence(useNext);
+        }
+
+        @Override
+        public int[] unrank() {
+            if (length == 0) return new int[0];
+
+            BigInteger prevPermutationCounter = BigInteger.ONE;
+            BigInteger permutationCounter = BigInteger.ZERO;
+            BigInteger nCk = BigInteger.ONE;
+
+            int subsetSize = 1;
+            while (permutationCounter.compareTo(currentIndex) == -1) {
+                prevPermutationCounter = permutationCounter;
+                nCk = computeNextNchooseK(nCk, length, subsetSize - 1);
+                permutationCounter = permutationCounter.add(divisors[subsetSize].multiply(nCk.pow(2)));
+
+                subsetSize++;
+            }
+            subsetSize--;
+            BigInteger partialPermutationIndex = currentIndex.subtract(prevPermutationCounter);
+
+            return unrankPartialPermutation(partialPermutationIndex, nCk, subsetSize);
+        }
+
+        private int[] unrankPartialPermutation(BigInteger partialPermutationIndex, BigInteger nCk, int subsetSize) {
+            int numberOfHoleElements = length - subsetSize;
+            BigInteger lengthOfPermutations = divisors[length].divide(divisors[numberOfHoleElements]);
+
+            BigInteger[] quotientAndRemainder = partialPermutationIndex.divideAndRemainder(lengthOfPermutations);
+            BigInteger combinationIndex = quotientAndRemainder[0];
+            BigInteger permutationIndex = quotientAndRemainder[1];
+
+            if (permutationIndex.compareTo(BigInteger.ZERO) == 0) {
+                combinationIndex = combinationIndex.subtract(BigInteger.ONE);
+                permutationIndex = lengthOfPermutations;
+            }
+
+            int[] currentCombination = unrankCombination(length, subsetSize, nCk, combinationIndex);
+            int[] permutationStart = PartialPermutationSupplier.generateInitialSequence(currentCombination, length);
+            return unrankPermutation(permutationStart, permutationIndex.subtract(BigInteger.ONE), numberOfHoleElements, lengthOfPermutations);
+        }
+
+        /**
+         * Parameterized version of {@link CombinationSupplier.BigInt#unrank()}
+         * <p>
+         * This implementation uses the UNRANKCOMB-D algorithm introduced in:
+         * Kokosinski, Zbigniew, and Ikki-Machi Tsuruga. "Algorithms for unranking combinations and other related choice functions." (1995).
+         */
+        private int[] unrankCombination(int n, int k, BigInteger count, BigInteger currentIndex) {
+            if (k == 0) return new int[0];
+            int[] combi = new int[k];
+            BigInteger rank = count.subtract(BigInteger.ONE).subtract(currentIndex);
+            BigInteger e = count.multiply(BigInteger.valueOf(n - k)).divide(BigInteger.valueOf(n));
+            int t = n - k + 1;
+            int m = k;
+            int p = n - 1;
+            do {
+                if (e.compareTo(rank) <= 0) {
+                    combi[k - m] = n - t - m + 1;
+                    if (e.compareTo(BigInteger.ZERO) > 0) {
+                        rank = rank.subtract(e);
+                        e = e.multiply(BigInteger.valueOf(m)).divide(BigInteger.valueOf(p));
+                    }
+                    m--;
+                    p--;
+                } else {
+                    e = e.multiply(BigInteger.valueOf(p - m)).divide(BigInteger.valueOf(p));
+                    t--;
+                    p--;
+                }
+            } while (m > 0);
+            return combi;
+        }
+
+        private int[] unrankPermutation(int[] permutation, BigInteger rank, int numberOfHoleElements, BigInteger possiblePermutations) {
+            for (int step = 0; step < permutation.length; step++) {
+                int elementFrequency = Math.max(numberOfHoleElements, 1);
+                BigInteger numRemainingElements = BigInteger.valueOf(length - step);
+
+                BigInteger possibleSuffixes = possiblePermutations.multiply(BigInteger.valueOf(elementFrequency)).divide(numRemainingElements);
+
+                if (rank.compareTo(possibleSuffixes) == -1) {
+                    if (permutation[step] == HOLE) {
+                        numberOfHoleElements--;
+                    }
+
+                    possiblePermutations = possibleSuffixes;
+                } else {
+                    if (numberOfHoleElements > 1) {
+                        rank = rank.subtract(possibleSuffixes);
+                        possibleSuffixes = possiblePermutations.divide(numRemainingElements);
+                    }
+                    int targetOffset = rank.divide(possibleSuffixes).intValue();
+                    rank = rank.subtract(possibleSuffixes.multiply(BigInteger.valueOf(targetOffset)));
+
+                    if (numberOfHoleElements > 1) targetOffset += numberOfHoleElements;
+                    Long.reorderPermutation(permutation, step, targetOffset);
+
+                    possiblePermutations = possibleSuffixes;
+                }
+
+            }
+
+            return permutation;
+        }
+
+        private static BigInteger computeNextNchooseK(BigInteger prevNcK, int n, int k) {
+            BigInteger nCk = prevNcK.multiply(BigInteger.valueOf(n - k));
+            return nCk.divide(BigInteger.valueOf(k + 1));
+        }
+    }
+}

--- a/streamplify/src/main/java/org/beryx/streamplify/partperm/PartialPermutations.java
+++ b/streamplify/src/main/java/org/beryx/streamplify/partperm/PartialPermutations.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify.partperm;
+
+import org.beryx.streamplify.Streamable;
+import org.beryx.streamplify.StreamableProxy;
+
+/**
+ * A {@link Streamable} providing streams of permutations.
+ * <br>This class is a proxy that delegates to either {@link LongPartialPermutations} or {@link BigIntegerPartialPermutations}, depending on the permutation length.
+ */
+public class PartialPermutations extends StreamableProxy<int[], PartialPermutations> {
+    private final Streamable<int[], ?> delegate;
+
+    /**
+     * @param length the partial permutation length
+     */
+    public PartialPermutations(int length) {
+        if (length <= LongPartialPermutations.MAX_LENGTH) {
+            delegate = new LongPartialPermutations(length);
+        } else {
+            delegate = new BigIntegerPartialPermutations(length);
+        }
+    }
+
+    @Override
+    public Streamable<int[], ?> getDelegate() {
+        return delegate;
+    }
+}

--- a/streamplify/src/test/groovy/org/beryx/streamplify/PartialPermutationsSpec.groovy
+++ b/streamplify/src/test/groovy/org/beryx/streamplify/PartialPermutationsSpec.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.beryx.streamplify
+
+import org.beryx.streamplify.partperm.BigIntegerPartialPermutations
+import org.beryx.streamplify.partperm.LongPartialPermutations
+import org.beryx.streamplify.partperm.PartialPermutations
+import spock.lang.Specification
+
+import java.util.stream.Collectors
+
+class PartialPermutationsSpec extends Specification {
+
+    def "LongPartialPermutations should throw IllegalArgumentException for length #length"() {
+        when:
+        def partialPermutations = new LongPartialPermutations(length)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        length                                 | _
+        -1                                     | _
+        -2                                     | _
+        LongPartialPermutations.MAX_LENGTH + 1 | _
+        Integer.MAX_VALUE                      | _
+        -Integer.MAX_VALUE                     | _
+    }
+
+    def "BigIntegerPartialPermutations should throw IllegalArgumentException for length #length"() {
+        when:
+        def partialPermutations = new BigIntegerPartialPermutations(length)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        length                                       | _
+        -1                                           | _
+        -2                                           | _
+        BigIntegerPartialPermutations.MAX_LENGTH + 1 | _
+        Integer.MAX_VALUE                            | _
+        -Integer.MAX_VALUE                           | _
+    }
+
+    def "should use a #delegateClass.simpleName for length #length"() {
+        given:
+        def partialPermutations = new PartialPermutations(length)
+
+        expect:
+        partialPermutations.delegate.getClass().name == delegateClass.name
+
+        where:
+        length                                   | delegateClass
+        0                                        | LongPartialPermutations
+        1                                        | LongPartialPermutations
+        2                                        | LongPartialPermutations
+        LongPartialPermutations.MAX_LENGTH       | LongPartialPermutations
+        (LongPartialPermutations.MAX_LENGTH + 1) | BigIntegerPartialPermutations
+    }
+
+    def "LongPartialPermutations should correctly produce a partial permutation stream for length #length"() {
+        given:
+        def stream = new LongPartialPermutations(length).stream()
+
+        when:
+        def partialPerm = stream.map { int[] arr -> (arr as List).toString() }.collect(Collectors.toList())
+
+        then:
+        partialPerm == partialPermutations
+
+        where:
+        length | partialPermutations
+        0      | ['[]']
+        1      | ['[-1]', '[0]']
+        2      | ['[-1, -1]', '[-1, 0]', '[0, -1]', '[-1, 1]', '[1, -1]', '[0, 1]', '[1, 0]']
+    }
+
+    def "BigIntegerPartialPermutations should correctly produce a partial permutation stream for length #length"() {
+        given:
+        def stream = new BigIntegerPartialPermutations(length).stream()
+
+        when:
+        def partialPerm = stream.map { int[] arr -> (arr as List).toString() }.collect(Collectors.toList())
+
+        then:
+        partialPerm == partialPermutations
+
+        where:
+        length | partialPermutations
+        0      | ['[]']
+        1      | ['[-1]', '[0]']
+        2      | ['[-1, -1]', '[-1, 0]', '[0, -1]', '[-1, 1]', '[1, -1]', '[0, 1]', '[1, 0]']
+    }
+
+    def "PartialPermutations should skip correctly #skip partials permutations with length #length"() {
+        given:
+        def stream = new PartialPermutations(length).skip(skip).stream()
+
+        when:
+        def partialPerm = stream.map { int[] arr -> (arr as List).toString() }.findFirst().orElse('')
+
+        then:
+        partialPerm == permutation
+
+        where:
+        length | skip                                        | permutation
+        2      | 0                                           | '[-1, -1]'
+        2      | 1                                           | '[-1, 0]'
+        6      | 7329                                        | '[1, -1, -1, 4, 2, 5]'
+        25     | 10                                          | '[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1]'
+        21     | (new BigInteger('44552237162692939114280')) | '[20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 0, 1]'
+    }
+
+    def "LongPartialPermutations should calculate the correct number of partial permutations given length #length"() {
+        expect:
+        LongPartialPermutations.numberOfPermutations(length) == numberOfPartialPermutations
+
+        where:
+        length | numberOfPartialPermutations
+        0      | 1
+        1      | 2
+        7      | 130922
+        8      | 1441729
+        18     | 2968971263911288999
+    }
+
+    def "BigIntegerPartialPermutations should calculate the correct number of partial permutations given length #length"() {
+        expect:
+        BigIntegerPartialPermutations.numberOfPermutations(length) == numberOfPartialPermutations
+
+        where:
+        length | numberOfPartialPermutations
+        0      | 1
+        1      | 2
+        7      | 130922
+        30     | new BigInteger('1240758969214239528262796909096631871')
+    }
+
+}


### PR DESCRIPTION
implements issue #3:

Add support for partial permutation streams
Add docs using Asciidoctor
Add test: PartialPermutationsSpec.groovy
Add example: Vacation.java

As Parital permutations can be reduced down to a specialized combination and permutation problem, there is some code duplication with the Combination/Permutation value suppliers which could be consolidated.

This implementation currently only supports a single hole element, but I believe it can be extended to an arbitrary number of holes with some added complexity.
